### PR TITLE
Refactor: Centralize model_name in GeminiClient and simplify ChatSession

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,14 +34,13 @@ def main():
 
         # Inicializar el cliente de Gemini
         logger.info("Inicializando cliente de Gemini...")
-        client = GeminiClient()
+        client = GeminiClient(model_name=config.chat.default_model)
 
         # Crear una nueva sesión de chat
         session_id = "12345"
         context_manager = ContextManager(config.context.message_limit, config.context.context_messages)
         chat_session = ChatSession(
             session_id=session_id,
-            model_name=config.chat.default_model,
             client=client,
             context_manager=context_manager
         )

--- a/src/chat/chat_session.py
+++ b/src/chat/chat_session.py
@@ -10,7 +10,7 @@ of message history, context management, and interaction with AI models.
 Example:
     >>> from src.chat.chat_session import ChatSession
     >>> from src.models.message import Message
-    >>> session = ChatSession(session_id="12345", model_name="gemini-1.5-flash")
+    >>> session = ChatSession(session_id="12345", client=gemini_client_instance)
     >>> session.add_message(role="user", content="Hello!")
     >>> response = session.generate_response()
     >>> print(response.content)
@@ -32,20 +32,17 @@ class ChatSession:
     Manages a chat session, including message history and interactions with an AI model.
 
     """
-    def __init__(self, session_id: str, model_name: str, client: GeminiClient, context_manager: ContextManager):
+    def __init__(self, session_id: str, client: GeminiClient, context_manager: ContextManager):
         """
         Initializes a new ChatSession.
 
         Args:
             session_id (str): A unique identifier for the session.
-            model_name (str): The name of the AI model to use.
             client (GeminiClient): The client used to interact with the AI model.
-            max_messages (int): Maximum number of messages to retain in the context.
         """
         self.logger = logging.getLogger(__name__)  # Create a logger for this class
-        self.logger.info("Initializing ChatSession with session_id: %s and model_name: %s", session_id, model_name)
+        self.logger.info("Initializing ChatSession with session_id: %s", session_id)
         self.session_id = session_id  # Unique identifier for the session
-        self.model_name = model_name  # Name of the AI model used
         self.client = client
         self.context_manager = context_manager # Initialize ContextManager
         self._initialize_context()
@@ -116,7 +113,7 @@ class ChatSession:
         full_prompt = f"{history_text}\nUser: {prompt}"
 
         # Generate response using the AI model
-        response = self.client.generate_text(prompt=full_prompt, model_name=self.model_name)
+        response = self.client.generate_text(prompt=full_prompt)
         generated_text = response.generated_text if hasattr(response, "generated_text") else "Error: No se pudo generar una respuesta."
         self.logger.info("Generated response: %s", generated_text)
 


### PR DESCRIPTION
- `GeminiClient` now takes `model_name` only in its constructor; all methods use the instance attribute.
- Removed `model_name` from `ChatSession`—it now relies solely on the client for model selection.
- Simplified method signatures and updated usage accordingly.

Closes #13