### PR TITLE
feat(faiss): implement persistence for FAISS index with save and load functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ venv/
 # Misc
 .DS_Store
 *.log
+
+data/

--- a/faiss_test.py
+++ b/faiss_test.py
@@ -1,44 +1,52 @@
 # Integración básica de EmbeddingsGenerator y FAISSManager
 
-from src.embeddings.embeddings_generator import EmbeddingsGenerator
-from src.faiss.faiss_manager import FAISSManager
+from src.embeddings import EmbeddingsGenerator
+from src.faiss import FAISSManager
 
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
-from rich.markdown import Markdown
 
-# 1. Inicializa el generador y el manager
-emb_gen = EmbeddingsGenerator()
-faiss_mgr = FAISSManager(dimension=emb_gen.get_dimension())
+import os
+from pathlib import Path
 
-# 2. Prepara textos y genera embeddings
-texts = [
-    "La inteligencia artificial es fascinante.",
-    "La carpintería requiere precisión.",
-    "Los modelos de lenguaje procesan texto."
-]
-embeddings = emb_gen.generate(texts)  # shape: (3, 384)
+def main():
+    # Inicializa el generador y el manager
+    emb_gen = EmbeddingsGenerator()
+    faiss_index_path = Path(__file__).parent / "data" / "faiss_test_index"
+    faiss_mgr = FAISSManager(dimension=emb_gen.get_dimension())
 
-# 3. Añade los embeddings al índice FAISS
-faiss_mgr.add_embeddings(embeddings, texts)
+    # Intentar cargar el índice si existe
+    if (faiss_index_path.with_suffix(".index").exists() and
+        faiss_index_path.with_suffix(".texts.pkl").exists()):
+        faiss_mgr.load(str(faiss_index_path))
+        print("Índice FAISS cargado desde disco.")
+    else:
+        print("No existe índice FAISS persistente. Se creará uno nuevo.")
+        # Prepara textos y genera embeddings
+        texts = [
+            "La inteligencia artificial es fascinante.",
+            "La carpintería requiere precisión.",
+            "Los modelos de lenguaje procesan texto."
+        ]
+        embeddings = emb_gen.generate(texts)
+        faiss_mgr.add_embeddings(embeddings, texts)
+        faiss_mgr.save(str(faiss_index_path))
+        print("Índice FAISS guardado en disco.")
 
-# 4. Consulta: genera embedding y busca similares
-query = "¿Qué es la inteligencia artificial?"
-query_emb = emb_gen.generate([query])
-resultados = faiss_mgr.search(query_emb, k=2)
+    # Consulta: genera embedding y busca similares
+    query = "¿Qué es la inteligencia artificial?"
+    query_emb = emb_gen.generate([query])
+    resultados = faiss_mgr.search(query_emb, k=2)
 
-console = Console()
+    console = Console()
+    console.print(Panel.fit(f"[bold cyan]Consulta:[/bold cyan] {query}", title="🔎 Consulta FAISS"))
+    table = Table(title="Resultados más similares", show_lines=True)
+    table.add_column("Texto", style="magenta")
+    table.add_column("Distancia", style="green")
+    for texto, distancia in resultados:
+        table.add_row(texto, f"{distancia:.4f}")
+    console.print(table)
 
-# Mostrar la consulta
-console.print(Panel.fit(f"[bold cyan]Consulta:[/bold cyan] {query}", title="🔎 Consulta FAISS"))
-
-# Mostrar resultados en tabla
-table = Table(title="Resultados más similares", show_lines=True)
-table.add_column("Texto", style="magenta")
-table.add_column("Distancia", style="green")
-
-for texto, distancia in resultados:
-    table.add_row(texto, f"{distancia:.4f}")
-
-console.print(table)
+if __name__ == "__main__":
+    main()

--- a/src/faiss/faiss_manager.py
+++ b/src/faiss/faiss_manager.py
@@ -22,6 +22,8 @@ Dependencies:
 
 import faiss
 import numpy as np
+import pickle
+import os
 from typing import List, Tuple
 
 
@@ -95,3 +97,27 @@ class FAISSManager:
         """
         self.index.reset()
         self.texts.clear()
+
+    def save(self, path: str) -> None:
+        """
+        Saves the FAISS index and associated texts to disk for persistence.
+
+        Args:
+            path (str): The base path (without extension) to save the index and texts.
+        """
+        faiss.write_index(self.index, path + ".index")
+        with open(path + ".texts.pkl", "wb") as f:
+            pickle.dump(self.texts, f)
+
+    def load(self, path: str) -> None:
+        """
+        Loads the FAISS index and associated texts from disk.
+
+        Args:
+            path (str): The base path (without extension) to load the index and texts from.
+        """
+        if not os.path.exists(path + ".index") or not os.path.exists(path + ".texts.pkl"):
+            raise FileNotFoundError("Index or texts file not found at the specified path.")
+        self.index = faiss.read_index(path + ".index")
+        with open(path + ".texts.pkl", "rb") as f:
+            self.texts = pickle.load(f)


### PR DESCRIPTION
This pull request adds persistence support to the FAISSManager class, addressing issue #16.

**Key changes:**
- Added save and load methods to FAISSManager for persisting and restoring the FAISS index and associated texts using disk files.
- Updated faiss_test.py to demonstrate and test the new persistence functionality, saving to and loading from the data/ directory.
- Ensures that vector indexes can be reused across sessions, improving reliability for production and reproducibility.

**How to use:**
- Use FAISSManager.save(path) to persist the index and texts.
- Use FAISSManager.load(path) to restore them.
- See faiss_test.py for a complete example.

Closes #16